### PR TITLE
add an error type for validation errors

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -94,7 +94,7 @@ func MakeResource(name string, dependencies []Dependency, uDef interface{}, updF
 func (lib *Lib) Sync(ctxt context.Context, resources []Resource, toDelete bool) (map[string]string, error) {
 	err := check(resources)
 	if err != nil {
-		return nil, err
+		return nil, ValidationError{err.Error()}
 	}
 
 	g := buildGraph(resources)
@@ -134,7 +134,7 @@ func check(resources []Resource) error {
 				return err
 			}
 			if _, ok := cache[dep.FromResource]; !ok {
-				return fmt.Errorf("Dependent resource %s doesn't exist. Validation failure.", dep.FromResource)
+				return fmt.Errorf("Dependent resource %s doesn't exist", dep.FromResource)
 			}
 			if err := checkField(cache[dep.FromResource], dep.FromField); err != nil {
 				return err

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,11 @@
+package graph
+
+import "fmt"
+
+type ValidationError struct {
+	errorStr string
+}
+
+func (v ValidationError) Error() string {
+	return fmt.Sprintf("validation error: %s", v.errorStr)
+}


### PR DESCRIPTION
this specific error type will be used by the consumer (our deserializer) to ensure we don't retry validation errors