### PR TITLE
Added support for observability

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	yaml "gopkg.in/yaml.v2"
 
@@ -78,6 +79,21 @@ func (f *factory) applyOverrides(defaults *factory) {
 	}
 }
 
+type observer struct {
+}
+
+func (o *observer) ReportDuration(name, operation string, duration time.Duration) {
+	// report metrics here
+}
+
+func (o *observer) ReportStatus(name, operation string, success bool) {
+	// report metrics here
+}
+
+func getObserver() graph.Observer  {
+	return &observer{}
+}
+
 /*
 This example shows basic resource synchronization. There are three
 different resources that we need to build: an AWS Kinesis stream, an
@@ -109,7 +125,7 @@ func Example_usage() {
 		}
 	}
 
-	lib := graph.New(&graph.Opts{CustomLogger: myprint})
+	lib := graph.New(&graph.Opts{CustomLogger: myprint,Observer: getObserver()})
 
 	// fmt.Printf("factory: %v\n", f)
 

--- a/graph.go
+++ b/graph.go
@@ -35,11 +35,18 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"time"
 )
+
+type Observer interface {
+	ReportDuration(name, operation string, duration time.Duration)
+	ReportStatus(name, operation string, success bool)
+}
 
 // Opts captures customizable functionality like logging
 type Opts struct {
 	CustomLogger func(args ...interface{})
+	Observer Observer
 }
 
 // New creates an instance object
@@ -51,12 +58,17 @@ func New(opts *Opts) *Lib {
 		lib.logger = opts.CustomLogger
 	}
 
+	if opts != nil && opts.Observer != nil {
+		lib.observer = opts.Observer
+	}
+
 	return lib
 }
 
 // Lib object is required for using the library
 type Lib struct {
 	logger func(args ...interface{})
+	observer Observer
 }
 
 // graph data type


### PR DESCRIPTION
This PR adds the support for builder observability for time taken by the builder and the status of the builder. 

Client needs to implement the observe interface and pass it to the New() and graph lib will report if the interface is implemented. 